### PR TITLE
fix: better handling of Accounts

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,10 @@
+import { Account, Address, Chain } from "viem";
+
 export interface FacetTransactionParams {
   data?: `0x${string}` | undefined;
   to?: `0x${string}` | null | undefined;
   value?: bigint | undefined;
   extraData?: `0x${string}` | undefined;
+  chain?: Chain | undefined
+  account?: Account | Address | Account & { address: `0x${string}` } | `0x${string}` | undefined;
 }

--- a/src/viem/createFacetPublicClient.ts
+++ b/src/viem/createFacetPublicClient.ts
@@ -18,17 +18,19 @@ export type FacetPublicClient = Client<
   Account | undefined,
   RpcSchema,
   PublicActions<Transport, Chain | undefined, Account | undefined> &
-    PublicActionsL2<Chain | undefined, Account | undefined>
+  PublicActionsL2<Chain | undefined, Account | undefined>
 >;
 
-export const createFacetPublicClient = (
-  l1ChainId: 1 | 11_155_111
-): FacetPublicClient => {
-  if (l1ChainId === 1) {
+
+export function createFacetPublicClient(chain: Chain) {
+  if (chain?.id === 1) {
     throw new Error("Facet is not on mainnet");
   }
+
+  const net = chain.id === 1 ? "mainnet" : "sepolia";
+
   return createPublicClient({
-    chain: facetSepolia,
-    transport: http(),
+    chain,
+    transport: http(`https://${net}.facet.org`),
   }).extend(publicActionsL2());
-};
+}

--- a/src/viem/getFctMintRate.ts
+++ b/src/viem/getFctMintRate.ts
@@ -1,10 +1,11 @@
+import { Chain } from "viem";
 import { createFacetPublicClient } from "./createFacetPublicClient";
 
 const L1_BLOCK_CONTRACT =
   "0x4200000000000000000000000000000000000015" as `0x${string}`;
 
-export const getFctMintRate = async (l1ChainId: 1 | 11155111) => {
-  const facetPublicClient = createFacetPublicClient(l1ChainId);
+export const getFctMintRate = async (chain: Chain) => {
+  const facetPublicClient = createFacetPublicClient(chain);
 
   const fctMintRate = await facetPublicClient.readContract({
     address: L1_BLOCK_CONTRACT,


### PR DESCRIPTION
These changes allow us to use wallet clients that are using external wallets (eg. browser wallets and etc) with the `transport: custom(window.ethereum)` or any other EIP1193 provider such as Privy or Dynamic.

There are a couple of other small tweaks, but the idea is to accept two cases of use, and also allow passing it to the `params` of `sendTransaction`. In first case it's `Account` when you create it from `private key`, other case is when the client is created with extension-backed private key.

The account/address is not always coming from `walletClinet` (eg. `l1WalletClient.account` is empty).